### PR TITLE
bug: Remove lowercasing of job names now that buildnumber service is fixed.

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -311,7 +311,7 @@ func (c *controller) buildID(pj prowjobv1.ProwJob) (string, error) {
 	if pj.Spec.Refs.Repo == "" {
 		return "", fmt.Errorf("spec refs repo is empty")
 	}
-	jobName := strings.ToLower(fmt.Sprintf("%s/%s/%s", pj.Spec.Refs.Org, pj.Spec.Refs.Repo, branch))
+	jobName := fmt.Sprintf("%s/%s/%s", pj.Spec.Refs.Org, pj.Spec.Refs.Repo, branch)
 	logrus.Infof("get build id for jobname: %s, from URL %s", jobName, c.totURL)
 	return pjutil.GetBuildID(jobName, c.totURL)
 }


### PR DESCRIPTION
Undoing this workaround: https://github.com/jenkins-x/test-infra/commit/737645ee7301588fb33065acd9d5e15420c3457f
that was put in because the build number service failed for some job names with upper case characters. I've fixed that
bug now (by just putting back the ToLower _inside_ the build number service when genereating PipelineActivity.Name).
buildnumber service fix: https://github.com/jenkins-x/jx/pull/2558

Will /hold this PR until that one is deployed.

@rawlingsj - this is undoing your previous workaround due to the above changes in the buildnumber service. Reason is: preserving the case until inside the buildnumber service will mean it creates the PipelineActivity.Name in lowercase (`pr-123`), but the PipelineActivity.Pipeline in original case (`PR-123`). This is because I've seen some PipelineActivities that belong to the same Pipeline, but because they ref `PR-123` or `pr-123` they appear in the UI to be _different_ ones. (I think the underlying cause of _that_ is a conflict/race condition between the now lowercase form from prow and the uppercase form used by jx-resources-plugin).