### PR TITLE
Fixed the build_images.sh script to build statically linked binaries

### DIFF
--- a/prow/cmd/build_images.sh
+++ b/prow/cmd/build_images.sh
@@ -11,7 +11,8 @@ for i in $CMDS
 do
   echo "building ${i}"
   pushd ${i}
-    GOOS=linux GOARCH=amd64  go build ./...
+    # Need to build without dynamic linking to linux libraries to run in containers
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -a -ldflags '-extldflags "-static"' ./...
     docker build -t jenkinsxio/${i}:$TAG .
     docker push jenkinsxio/${i}:$TAG
   popd


### PR DESCRIPTION
TBH, I don't fully understand this, but without these additions, you
build a binary that's linked to libraries in the linux distro. If you
run those in a container without those shared libraries, you get a
`file not found` error. If you use the `file` utility, then you get:
```
/ # file build
build: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, not stripped
```

The `dynamically linked` part is the issue.

With these flags, you now get:
```
/ # file build
build: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```
where `statically linked` is your bestest friend ever.
The binary now runs on more docker images.