### PR TITLE
fix: Retry PipelineRuns that fail due to a Tekton race condition

### DIFF
--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -525,20 +525,20 @@ func reconcile(c reconciler, key string) error {
 		if err != nil {
 			return fmt.Errorf("no pipelinerun found with name %s: %v", name, err)
 		}
-		prowJobName := p.Labels[prowJobName]
-		if prowJobName == "" {
+		prowJob := p.Labels[prowJobName]
+		if prowJob == "" {
 			return fmt.Errorf("no prowjob name label for pipelinerun %s: %v", name, err)
 		}
 
-		pj, err = c.getProwJob(prowJobName)
+		pj, err = c.getProwJob(prowJob)
 		if err != nil {
 			return fmt.Errorf("no matching prowjob for pipelinerun %s: %v", name, err)
 		}
 
-		selector := fmt.Sprintf("%s = %s", prowJobName, name)
+		selector := fmt.Sprintf("%s = %s", prowJobName, pj.Name)
 		runs, err = c.getPipelineRunsWithSelector(ctx, namespace, selector)
 		if err != nil {
-			return fmt.Errorf("get pipelineruns %s by prow job %s: %v", key, prowJobName, err)
+			return fmt.Errorf("get pipelineruns %s by label %s:%s %v", key, prowJobName, pj.Name, err)
 		}
 		havePipelineRun = true
 

--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -992,7 +992,101 @@ func TestReconcile(t *testing.T) {
 				return pj
 			},
 			expectedPipelineRun: noPipelineRunChange,
-		}}
+		},
+		{
+			name: "prowjob retries when pipeline run fails with race condition",
+			observedJob: &prowjobv1.ProwJob{
+				Spec: prowjobv1.ProwJobSpec{
+					Agent:           prowjobv1.TektonAgent,
+					PipelineRunSpec: &pipelineSpec,
+				},
+				Status: prowjobv1.ProwJobStatus{
+					State:       prowjobv1.PendingState,
+					Description: "fancy",
+				},
+			},
+			observedPipelineRuns: func() []*pipelinev1alpha1.PipelineRun {
+				pj := prowjobv1.ProwJob{}
+				pj.Spec.Type = prowjobv1.PeriodicJob
+				pj.Spec.Agent = prowjobv1.TektonAgent
+				pj.Spec.PipelineRunSpec = &pipelineSpec
+				pr := makePipelineGitResource(pj)
+				p, err := makePipelineRun(pj, "21", pr)
+				if err != nil {
+					panic(err)
+				}
+				p.Status.SetCondition(&duckv1alpha1.Condition{
+					Type:    duckv1alpha1.ConditionSucceeded,
+					Status:  corev1.ConditionFalse,
+					Message: "Pipeline jx/jenkins-x-jx-pr-5266-images-16 can't be found:pipeline.tekton.dev\n" +
+						"\"jenkins-x-jx-pr-5266-images-16\" not found",
+				})
+				p.CreationTimestamp = metav1.Now()
+				return []*pipelinev1alpha1.PipelineRun{p}
+			}(),
+			expectedJob: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob {
+				pj.Status = prowjobv1.ProwJobStatus{
+					StartTime:      now,
+					State:          prowjobv1.TriggeredState,
+				}
+				return pj
+			},
+			expectedPipelineRun: nil,
+		},
+		{
+			name: "with successful metapipeline and failed pipeline with race condition",
+			observedJob: &prowjobv1.ProwJob{
+				Spec: prowjobv1.ProwJobSpec{
+					Agent:           prowjobv1.TektonAgent,
+					PipelineRunSpec: &pipelineSpec,
+				},
+				Status: prowjobv1.ProwJobStatus{
+					State:       prowjobv1.PendingState,
+					Description: "fancy",
+				},
+			},
+			observedPipelineRuns: func() []*pipelinev1alpha1.PipelineRun {
+				pj := prowjobv1.ProwJob{}
+				pj.Spec.Type = prowjobv1.PeriodicJob
+				pj.Spec.Agent = prowjobv1.TektonAgent
+				pj.Spec.PipelineRunSpec = &pipelinev1alpha1.PipelineRunSpec{
+					ServiceAccount: "robot",
+				}
+				pr := makePipelineGitResource(pj)
+				metaP, err := makePipelineRunWithPrefix(pj, "5", pr, "meta")
+				if err != nil {
+					panic(err)
+				}
+				metaP.Status.SetCondition(&duckv1alpha1.Condition{
+					Type:    duckv1alpha1.ConditionSucceeded,
+					Status:  corev1.ConditionTrue,
+					Reason:  "Succeeded",
+					Message: "Metapipeline",
+				})
+				metaP.CreationTimestamp = metav1.Now()
+				execP, err := makePipelineRun(pj, "5", pr)
+				if err != nil {
+					panic(err)
+				}
+				execP.Status.SetCondition(&duckv1alpha1.Condition{
+					Type:    duckv1alpha1.ConditionSucceeded,
+					Status:  corev1.ConditionFalse,
+					Message: "Pipeline jx/jenkins-x-jx-pr-5266-images-16 can't be found:pipeline.tekton.dev\n" +
+						"\"jenkins-x-jx-pr-5266-images-16\" not found",
+				})
+				execP.CreationTimestamp = metav1.Now()
+				return []*pipelinev1alpha1.PipelineRun{metaP, execP}
+			}(),
+			expectedJob: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob {
+				pj.Status = prowjobv1.ProwJobStatus{
+					StartTime:      now,
+					State:          prowjobv1.TriggeredState,
+				}
+				return pj
+			},
+			expectedPipelineRun: nil,
+		},
+	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -94,6 +94,19 @@ func (r *fakeReconciler) patchProwJob(pj *prowjobv1.ProwJob) error {
 	return err
 }
 
+func (r *fakeReconciler) patchPipelineRun(context, namespace string, pr *pipelinev1alpha1.PipelineRun) error {
+	logrus.Debugf("patchPipelineRun: name=%s", pr.GetName())
+	if pr == nil {
+		return errors.New("nil pipelinerun")
+	}
+	k := toKey(context, namespace, pr.GetName(), pipelineRun)
+	if _, present := r.pipelines[k]; !present {
+		return apierrors.NewNotFound(pipelinev1alpha1.Resource("PipelineRun"), pr.GetName())
+	}
+	r.pipelines[k] = *pr
+	return nil
+}
+
 func (r *fakeReconciler) getPipelineRun(context, namespace, name string) (*pipelinev1alpha1.PipelineRun, error) {
 	logrus.Debugf("getPipelineRun: ctx=%s, ns=%s, name=%s", context, namespace, name)
 	if namespace == errorGetPipelineRun {
@@ -294,14 +307,15 @@ func TestReconcile(t *testing.T) {
 		return p
 	}
 	cases := []struct {
-		name                 string
-		namespace            string
-		context              string
-		observedJob          *prowjobv1.ProwJob
-		observedPipelineRuns []*pipelinev1alpha1.PipelineRun
-		expectedJob          func(prowjobv1.ProwJob, pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob
-		expectedPipelineRun  func(prowjobv1.ProwJob, pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun
-		err                  bool
+		name                   string
+		namespace              string
+		context                string
+		observedJob            *prowjobv1.ProwJob
+		observedPipelineRuns   []*pipelinev1alpha1.PipelineRun
+		expectedJob            func(prowjobv1.ProwJob, pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob
+		expectedPipelineRun    func(prowjobv1.ProwJob, pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun
+		reconcileAndDeleteRuns bool
+		err                    bool
 	}{{
 		name: "new prow job creates pipeline",
 		observedJob: &prowjobv1.ProwJob{
@@ -1016,8 +1030,8 @@ func TestReconcile(t *testing.T) {
 					panic(err)
 				}
 				p.Status.SetCondition(&duckv1alpha1.Condition{
-					Type:    duckv1alpha1.ConditionSucceeded,
-					Status:  corev1.ConditionFalse,
+					Type:   duckv1alpha1.ConditionSucceeded,
+					Status: corev1.ConditionFalse,
 					Message: "Pipeline jx/jenkins-x-jx-pr-5266-images-16 can't be found:pipeline.tekton.dev\n" +
 						"\"jenkins-x-jx-pr-5266-images-16\" not found",
 				})
@@ -1026,12 +1040,16 @@ func TestReconcile(t *testing.T) {
 			}(),
 			expectedJob: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob {
 				pj.Status = prowjobv1.ProwJobStatus{
-					StartTime:      now,
-					State:          prowjobv1.TriggeredState,
+					StartTime: now,
+					State:     prowjobv1.TriggeredState,
 				}
 				return pj
 			},
-			expectedPipelineRun: nil,
+			expectedPipelineRun: func(_ prowjobv1.ProwJob, p pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun {
+				p.DeletionTimestamp = &now
+				return p
+			},
+			reconcileAndDeleteRuns: true,
 		},
 		{
 			name: "with successful metapipeline and failed pipeline with race condition",
@@ -1069,8 +1087,8 @@ func TestReconcile(t *testing.T) {
 					panic(err)
 				}
 				execP.Status.SetCondition(&duckv1alpha1.Condition{
-					Type:    duckv1alpha1.ConditionSucceeded,
-					Status:  corev1.ConditionFalse,
+					Type:   duckv1alpha1.ConditionSucceeded,
+					Status: corev1.ConditionFalse,
 					Message: "Pipeline jx/jenkins-x-jx-pr-5266-images-16 can't be found:pipeline.tekton.dev\n" +
 						"\"jenkins-x-jx-pr-5266-images-16\" not found",
 				})
@@ -1079,12 +1097,16 @@ func TestReconcile(t *testing.T) {
 			}(),
 			expectedJob: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob {
 				pj.Status = prowjobv1.ProwJobStatus{
-					StartTime:      now,
-					State:          prowjobv1.TriggeredState,
+					StartTime: now,
+					State:     prowjobv1.TriggeredState,
 				}
 				return pj
 			},
-			expectedPipelineRun: nil,
+			expectedPipelineRun: func(_ prowjobv1.ProwJob, p pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun {
+				p.DeletionTimestamp = &now
+				return p
+			},
+			reconcileAndDeleteRuns: true,
 		},
 	}
 
@@ -1117,17 +1139,20 @@ func TestReconcile(t *testing.T) {
 				p := tc.observedPipelineRuns[0]
 				p.Name = name
 				p.Labels[kube.ProwJobIDLabel] = name
+				p.Labels[prowJobName] = name
 				r.pipelines[pk] = *p
 			} else if len(tc.observedPipelineRuns) == 2 {
 				// The first is going to be the meta pipeline, the second the executing pipeline
 				mp := tc.observedPipelineRuns[0]
 				mp.Name = "meta-" + name
 				mp.Labels[kube.ProwJobIDLabel] = name
+				mp.Labels[prowJobName] = name
 				r.pipelines[metapk] = *mp
 
 				p := tc.observedPipelineRuns[1]
 				p.Name = name
 				p.Labels[kube.ProwJobIDLabel] = name
+				p.Labels[prowJobName] = name
 				r.pipelines[pk] = *p
 			}
 
@@ -1156,6 +1181,23 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("prowjobs do not match:\n%s", diff.ObjectReflectDiff(expectedJobs, r.jobs))
 			case !equality.Semantic.DeepEqual(r.pipelines, expectedPipelineRuns):
 				t.Errorf("pipelineruns do not match:\n%s", diff.ObjectReflectDiff(expectedPipelineRuns, r.pipelines))
+			}
+
+			if tc.reconcileAndDeleteRuns {
+				for k, _ := range expectedPipelineRuns {
+					err := reconcile(r, k)
+					if err != nil {
+						if !tc.err {
+							t.Errorf("unexpected error: %v", err)
+						}
+					}
+				}
+
+				for k, _ := range expectedPipelineRuns {
+					if _, ok := r.pipelines[k]; ok {
+						t.Errorf("expected PipelineRun %s to have been deleted but is still present", k)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
If we see a particular string in the failure message for a
`PipelineRun`, we know it's due to a race condition in Tekton where
the `PipelineRun` starts getting handled by the controller but its
cache of `Pipeline`s doesn't yet contain the relevant `Pipeline`. So
when we see that, let's reset the `ProwJob` and delete the
existing-but-failed `PipelineRun`(s) so that we can retry.

fixes https://github.com/jenkins-x/jx/issues/5324

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>