### PR TITLE
fix: Use "build" label, not "build_id" param to find PR ID/number

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -86,3 +86,6 @@ pipelineConfig:
             - name: build-and-push-image
               image: gcr.io/jenkinsxio/prow-builder:0.0.5
               command: /workspace/source/prow/push.sh
+            - name: update-bot
+              image: gcr.io/jenkinsxio/builder-maven:0.1.742
+              command: /workspace/source/prow/update-bot.sh

--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -693,10 +693,8 @@ func updateProwJobState(c reconciler, pj *prowjobv1.ProwJob, state prowjobv1.Pro
 			npj.Status.Description = msg
 
 			// Set the status build ID and URL if they're empty
-			for _, r := range runs {
-				if npj.Status.BuildID != "" && npj.Status.URL != "" {
-					continue
-				}
+			if len(runs) > 0 && (npj.Status.BuildID == "" || npj.Status.URL == "") {
+				r := runs[0]
 				logrus.Infof("Setting build ID and URL for ProwJob/%s from PipelineRun %s", pj.GetName(), r.Name)
 				npj.Status.BuildID = getBuildNumber(r)
 				npj.Status.URL = c.getProwJobURL(*pj)

--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -61,10 +61,11 @@ import (
 )
 
 const (
-	controllerName = "prow-pipeline-crd"
-	prowJobName    = "prowJobName"
-	pipelineRun    = "PipelineRun"
-	prowJob        = "ProwJob"
+	controllerName   = "prow-pipeline-crd"
+	prowJobName      = "prowJobName"
+	pipelineRun      = "PipelineRun"
+	prowJob          = "ProwJob"
+	buildNumberLabel = "build"
 
 	// Abort pipeline run request which don't return in 5 mins.
 	maxPipelineRunRequestTimeout = 5 * time.Minute
@@ -877,7 +878,7 @@ func makePipelineRunWithPrefix(pj prowjobv1.ProwJob, buildID string, pr *pipelin
 		Name:  "build_id",
 		Value: buildID,
 	})
-	p.Labels["build"] = buildID
+	p.Labels[buildNumberLabel] = buildID
 
 	rb := pipelinev1alpha1.PipelineResourceBinding{
 		Name: name,
@@ -953,7 +954,7 @@ func (c *controller) requestPipelineRun(context, namespace string, pj prowjobv1.
 }
 
 func getBuildNumber(pr *pipelinev1alpha1.PipelineRun) string {
-	buildNum := pr.Labels["build"]
+	buildNum := pr.Labels[buildNumberLabel]
 	if buildNum != "" {
 		return buildNum
 	}

--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -535,6 +535,7 @@ func TestReconcile(t *testing.T) {
 			expectedJob: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob {
 				pj.Status.State = prowjobv1.TriggeredState
 				pj.Status.Description = descScheduling
+				pj.Status.BuildID = "5"
 				return pj
 			},
 			expectedPipelineRun: noPipelineRunChange,
@@ -573,6 +574,7 @@ func TestReconcile(t *testing.T) {
 					StartTime:   now,
 					State:       prowjobv1.TriggeredState,
 					Description: "scheduling",
+					BuildID:     "1",
 				}
 				return pj
 			},
@@ -614,6 +616,7 @@ func TestReconcile(t *testing.T) {
 					CompletionTime: &now,
 					State:          prowjobv1.SuccessState,
 					Description:    "hello",
+					BuildID:        "22",
 				}
 				return pj
 			},
@@ -655,6 +658,7 @@ func TestReconcile(t *testing.T) {
 					CompletionTime: &now,
 					State:          prowjobv1.FailureState,
 					Description:    "hello",
+					BuildID:        "21",
 				}
 				return pj
 			},
@@ -840,6 +844,7 @@ func TestReconcile(t *testing.T) {
 					CompletionTime: &now,
 					State:          prowjobv1.SuccessState,
 					Description:    "Exec pipeline",
+					BuildID:        "5",
 				}
 				return pj
 			},
@@ -895,6 +900,7 @@ func TestReconcile(t *testing.T) {
 					StartTime:   now,
 					State:       prowjobv1.PendingState,
 					Description: "Exec pipeline",
+					BuildID:     "5",
 				}
 				return pj
 			},
@@ -950,6 +956,7 @@ func TestReconcile(t *testing.T) {
 					CompletionTime: &now,
 					State:          prowjobv1.FailureState,
 					Description:    "Exec pipeline",
+					BuildID:        "5",
 				}
 				return pj
 			},
@@ -1002,6 +1009,7 @@ func TestReconcile(t *testing.T) {
 					StartTime:   now,
 					State:       prowjobv1.TriggeredState,
 					Description: "scheduling",
+					BuildID:     "5",
 				}
 				return pj
 			},

--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -1446,6 +1446,7 @@ func TestMakePipelineRun(t *testing.T) {
 				ObjectMeta: pipelineMeta(pj),
 				Spec:       *pj.Spec.PipelineRunSpec,
 			}
+			expected.Labels[buildNumberLabel] = "so-many-pipelines"
 			expected.Spec.Params = append(expected.Spec.Params, pipelinev1alpha1.Param{
 				Name:  "build_id",
 				Value: randomPipelineRunID,

--- a/prow/update-bot.sh
+++ b/prow/update-bot.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Get the new version - since we're pushing via Prow's own bazel-based logic, we don't actually know the version ahead
+# of time. So use the same command used in push.sh to get the version.
+new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"
+
+jx step create pr chart --name gcr.io/jenkinsxio/prow --version ${new_version} --repo https://github.com/jenkins-x-charts/prow.git


### PR DESCRIPTION
Also update `pj.Status.BuildID` and `pj.Status.URL` if unset during
reconciliation.

fixes https://github.com/jenkins-x/jx/issues/5394

/assign @ccojocar 
/assign @hferentschik 